### PR TITLE
Some codegen fixes

### DIFF
--- a/src/ElmHttpGenerator.elm
+++ b/src/ElmHttpGenerator.elm
@@ -3,37 +3,59 @@ module ElmHttpGenerator exposing (generate)
 import Elm
 import Elm.Annotation
 import Elm.Gen.Http
+import Elm.Pattern
 import InterpolatedField
 import Request exposing (Request)
 
 
 generate : Request -> Elm.Declaration
 generate request =
+    let
+        referencedVariables : List InterpolatedField.Variable
+        referencedVariables =
+            request.headers
+                |> List.concatMap
+                    (\( key, value ) ->
+                        InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
+                    )
+    in
     (if List.isEmpty request.headers then
-        \_ ->
-            Elm.Gen.Http.get
-                { url = Elm.string request.url
-                , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
-                }
+        Elm.Gen.Http.get
+            { url = Elm.string request.url
+            , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
+            }
 
      else
-        \_ ->
-            Elm.Gen.Http.request
-                { url = Elm.string request.url
-                , headers =
-                    request.headers
-                        |> List.map
-                            (\( key, value ) ->
-                                Elm.Gen.Http.header
-                                    (InterpolatedField.toElmExpression key)
-                                    (InterpolatedField.toElmExpression value)
-                            )
-                        |> Elm.list
-                , method = request.method |> Request.methodToString |> Elm.string
-                , body = Elm.Gen.Http.emptyBody
-                , timeout = Elm.value "Nothing"
-                , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
-                , tracker = Elm.value "Nothing"
-                }
+        Elm.Gen.Http.request
+            { url = Elm.string request.url
+            , headers =
+                request.headers
+                    |> List.map
+                        (\( key, value ) ->
+                            Elm.Gen.Http.header
+                                (InterpolatedField.toElmExpression key)
+                                (InterpolatedField.toElmExpression value)
+                        )
+                    |> Elm.list
+            , method = request.method |> Request.methodToString |> Elm.string
+            , body = Elm.Gen.Http.emptyBody
+            , timeout = Elm.value "Nothing"
+            , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
+            , tracker = Elm.value "Nothing"
+            }
     )
-        |> Elm.fn "request" ( "toMsg", Elm.Annotation.unit )
+        |> Elm.functionWith "request"
+            (toMsgParam
+                :: List.map
+                    (\variable ->
+                        ( Elm.Annotation.string
+                        , InterpolatedField.toElmVar variable
+                        )
+                    )
+                    referencedVariables
+            )
+
+
+toMsgParam : ( Elm.Annotation.Annotation, Elm.Pattern.Pattern )
+toMsgParam =
+    ( Elm.Annotation.unit, Elm.Pattern.var "toMsg" )

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -282,7 +282,7 @@ elmPagesCodeGen model =
                     Fusion.Json.decoderFromTType tType
     in
     """import DataSource.Http
-import Secrets
+import Pages.Secrets
 import OptimizedDecoder as D
 import OptimizedDecoder.Pipeline exposing (required)
 

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -316,7 +316,7 @@ import Json.Decode as D
 import Json.Decode.Pipeline exposing (required)
 
    
-   """
+"""
         ++ (model.currentRequest
                 |> ElmHttpGenerator.generate
                 |> Elm.declarationToString

--- a/tests/ElmHttpGeneratorTest.elm
+++ b/tests/ElmHttpGeneratorTest.elm
@@ -53,6 +53,33 @@ suite =
         , timeout = Nothing
         , tracker = Nothing
         }"""
+        , test "GET with parameters" <|
+            \() ->
+                { url = "https://example.com"
+                , method = Request.GET
+                , body = Request.Empty
+                , headers =
+                    [ ( "accept-language", "${PREFERRED_LANGUAGE};q=0.9" )
+                    , ( "Referer", "http://www.wikipedia.org/" )
+                    ]
+                }
+                    |> toRequest
+                    |> ElmHttpGenerator.generate
+                    |> Elm.declarationToString
+                    |> Expect.equal
+                        """request toMsg preferredLanguage =
+    Http.request
+        { method = "GET"
+        , headers =
+            [ Http.header "accept-language" (preferredLanguage ++ ";q=0.9")
+            , Http.header "Referer" "http://www.wikipedia.org/"
+            ]
+        , url = "https://example.com"
+        , body = Http.emptyBody
+        , expect = Http.expectJson toMsg decoder
+        , timeout = Nothing
+        , tracker = Nothing
+        }"""
         ]
 
 


### PR DESCRIPTION
- Fixes a small indentation issue in the elm/http codegen
- Adds parameters for each referenced bash variable in the elm/http generated code
- Fixes the names of import aliases to match the elm-prefab version of code so the imports will line up correctly with the generated code