### PR TITLE
Variables UI

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -32,6 +32,7 @@
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/elm-syntax": "7.2.8",
             "the-sett/elm-pretty-printer": "3.0.0",
+            "truqu/elm-base64": "2.0.4",
             "truqu/elm-oauth2": "7.0.1",
             "turboMaCk/non-empty-list-alias": "1.1.0"
         },

--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -55,9 +55,9 @@ update msg model =
 updateFromFrontend : SessionId -> ClientId -> ToBackend -> Model -> ( Model, Cmd BackendMsg )
 updateFromFrontend sessionId clientId msg model =
     case msg of
-        RequestExecClicked_ request ->
+        RequestExecClicked_ variables request ->
             ( { model | httpRequest = RemoteData.Loading }
-            , request |> Fusion.HTTP.toHttpRequestTask |> Task.attempt (RequestExecResult clientId)
+            , request |> Fusion.HTTP.toHttpRequestTask variables |> Task.attempt (RequestExecResult clientId)
             )
 
         NoOpToBackend ->

--- a/src/Curl.elm
+++ b/src/Curl.elm
@@ -87,7 +87,7 @@ curl =
                         |> List.map splitHeader
                         |> Dict.fromList
             in
-            { url = url
+            { url = url |> InterpolatedField.fromString
             , method =
                 if data == [] then
                     Request.GET

--- a/src/DataSourceGenerator.elm
+++ b/src/DataSourceGenerator.elm
@@ -13,6 +13,26 @@ import Request exposing (Request)
 generate : Request -> Elm.Declaration
 generate request =
     let
+        authHeaders : List Elm.Expression
+        authHeaders =
+            case request.auth of
+                Just (Request.BasicAuth basicAuth) ->
+                    [ Elm.tuple
+                        (Elm.string "Authorization")
+                        (Elm.apply (Elm.value "Base64.encode")
+                            [ Elm.append
+                                (Elm.append
+                                    (InterpolatedField.toElmExpression basicAuth.username)
+                                    (Elm.string ":")
+                                )
+                                (InterpolatedField.toElmExpression basicAuth.password)
+                            ]
+                        )
+                    ]
+
+                _ ->
+                    []
+
         requestRecordExpression : Elm.Expression
         requestRecordExpression =
             Elm.record
@@ -26,6 +46,7 @@ generate request =
                                     (InterpolatedField.toElmExpression key)
                                     (InterpolatedField.toElmExpression value)
                             )
+                        |> List.append authHeaders
                         |> Elm.list
                     )
                 , Elm.field "body" (bodyGenerator request)

--- a/src/DataSourceGenerator.elm
+++ b/src/DataSourceGenerator.elm
@@ -55,7 +55,7 @@ generate request =
                 secretsPipeline : Elm.Expression
                 secretsPipeline =
                     variables
-                        |> List.NonEmpty.map (\variable -> Elm.apply (Elm.value "Secrets.with") [ Elm.string (InterpolatedField.variableName variable) ])
+                        |> List.NonEmpty.map (\variable -> Elm.apply (Elm.value "Secrets.with") [ Elm.string (InterpolatedField.rawVariableName variable) ])
                         |> List.NonEmpty.cons requestLambda
                         |> List.NonEmpty.foldr1 Elm.pipe
             in

--- a/src/DataSourceGenerator.elm
+++ b/src/DataSourceGenerator.elm
@@ -13,16 +13,6 @@ import Request exposing (Request)
 generate : Request -> Elm.Declaration
 generate request =
     let
-        referencedVariables : Maybe (List.NonEmpty.NonEmpty InterpolatedField.Variable)
-        referencedVariables =
-            request.headers
-                |> List.concatMap
-                    (\( key, value ) ->
-                        InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
-                    )
-                |> List.append (InterpolatedField.referencedVariables request.url)
-                |> List.NonEmpty.fromList
-
         requestRecordExpression : Elm.Expression
         requestRecordExpression =
             Elm.record
@@ -41,7 +31,7 @@ generate request =
                 , Elm.field "body" (bodyGenerator request)
                 ]
     in
-    (case referencedVariables of
+    (case request |> Request.referencedVariables |> List.NonEmpty.fromList of
         Nothing ->
             Elm.Gen.DataSource.Http.request
                 (requestRecordExpression |> Elm.Gen.Pages.Secrets.succeed)

--- a/src/DataSourceGenerator.elm
+++ b/src/DataSourceGenerator.elm
@@ -20,12 +20,13 @@ generate request =
                     (\( key, value ) ->
                         InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
                     )
+                |> List.append (InterpolatedField.referencedVariables request.url)
                 |> List.NonEmpty.fromList
 
         requestRecordExpression : Elm.Expression
         requestRecordExpression =
             Elm.record
-                [ Elm.field "url" (Elm.string request.url)
+                [ Elm.field "url" (request.url |> InterpolatedField.toElmExpression)
                 , Elm.field "method" (request.method |> Request.methodToString |> Elm.string)
                 , Elm.field "headers"
                     (request.headers

--- a/src/ElmHttpGenerator.elm
+++ b/src/ElmHttpGenerator.elm
@@ -3,37 +3,59 @@ module ElmHttpGenerator exposing (generate)
 import Elm
 import Elm.Annotation
 import Elm.Gen.Http
+import Elm.Pattern
 import InterpolatedField
 import Request exposing (Request)
 
 
 generate : Request -> Elm.Declaration
 generate request =
+    let
+        referencedVariables : List InterpolatedField.Variable
+        referencedVariables =
+            request.headers
+                |> List.concatMap
+                    (\( key, value ) ->
+                        InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
+                    )
+    in
     (if List.isEmpty request.headers then
-        \_ ->
-            Elm.Gen.Http.get
-                { url = Elm.string request.url
-                , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
-                }
+        Elm.Gen.Http.get
+            { url = Elm.string request.url
+            , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
+            }
 
      else
-        \_ ->
-            Elm.Gen.Http.request
-                { url = Elm.string request.url
-                , headers =
-                    request.headers
-                        |> List.map
-                            (\( key, value ) ->
-                                Elm.Gen.Http.header
-                                    (InterpolatedField.toElmExpression key)
-                                    (InterpolatedField.toElmExpression value)
-                            )
-                        |> Elm.list
-                , method = request.method |> Request.methodToString |> Elm.string
-                , body = Elm.Gen.Http.emptyBody
-                , timeout = Elm.value "Nothing"
-                , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
-                , tracker = Elm.value "Nothing"
-                }
+        Elm.Gen.Http.request
+            { url = Elm.string request.url
+            , headers =
+                request.headers
+                    |> List.map
+                        (\( key, value ) ->
+                            Elm.Gen.Http.header
+                                (InterpolatedField.toElmExpression key)
+                                (InterpolatedField.toElmExpression value)
+                        )
+                    |> Elm.list
+            , method = request.method |> Request.methodToString |> Elm.string
+            , body = Elm.Gen.Http.emptyBody
+            , timeout = Elm.value "Nothing"
+            , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
+            , tracker = Elm.value "Nothing"
+            }
     )
-        |> Elm.fn "request" ( "toMsg", Elm.Annotation.unit )
+        |> Elm.functionWith "request"
+            (toMsgParam
+                :: List.map
+                    (\variable ->
+                        ( Elm.Annotation.string
+                        , InterpolatedField.toElmVar variable
+                        )
+                    )
+                    referencedVariables
+            )
+
+
+toMsgParam : ( Elm.Annotation.Annotation, Elm.Pattern.Pattern )
+toMsgParam =
+    ( Elm.Annotation.unit, Elm.Pattern.var "toMsg" )

--- a/src/ElmHttpGenerator.elm
+++ b/src/ElmHttpGenerator.elm
@@ -10,16 +10,6 @@ import Request exposing (Request)
 
 generate : Request -> Elm.Declaration
 generate request =
-    let
-        referencedVariables : List InterpolatedField.Variable
-        referencedVariables =
-            request.headers
-                |> List.concatMap
-                    (\( key, value ) ->
-                        InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
-                    )
-                |> List.append (InterpolatedField.referencedVariables request.url)
-    in
     (if List.isEmpty request.headers then
         Elm.Gen.Http.get
             { url = InterpolatedField.toElmExpression request.url
@@ -53,7 +43,7 @@ generate request =
                         , InterpolatedField.toElmVar variable
                         )
                     )
-                    referencedVariables
+                    (Request.referencedVariables request)
             )
 
 

--- a/src/ElmHttpGenerator.elm
+++ b/src/ElmHttpGenerator.elm
@@ -18,16 +18,17 @@ generate request =
                     (\( key, value ) ->
                         InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
                     )
+                |> List.append (InterpolatedField.referencedVariables request.url)
     in
     (if List.isEmpty request.headers then
         Elm.Gen.Http.get
-            { url = Elm.string request.url
+            { url = InterpolatedField.toElmExpression request.url
             , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
             }
 
      else
         Elm.Gen.Http.request
-            { url = Elm.string request.url
+            { url = InterpolatedField.toElmExpression request.url
             , headers =
                 request.headers
                     |> List.map

--- a/src/ElmHttpGenerator.elm
+++ b/src/ElmHttpGenerator.elm
@@ -10,7 +10,28 @@ import Request exposing (Request)
 
 generate : Request -> Elm.Declaration
 generate request =
-    (if List.isEmpty request.headers then
+    let
+        authHeaders : List Elm.Expression
+        authHeaders =
+            case request.auth of
+                Just (Request.BasicAuth basicAuth) ->
+                    [ Elm.Gen.Http.header
+                        (Elm.string "Authorization")
+                        (Elm.apply (Elm.value "Base64.encode")
+                            [ Elm.append
+                                (Elm.append
+                                    (InterpolatedField.toElmExpression basicAuth.username)
+                                    (Elm.string ":")
+                                )
+                                (InterpolatedField.toElmExpression basicAuth.password)
+                            ]
+                        )
+                    ]
+
+                _ ->
+                    []
+    in
+    (if List.isEmpty request.headers && List.isEmpty authHeaders then
         Elm.Gen.Http.get
             { url = InterpolatedField.toElmExpression request.url
             , expect = Elm.Gen.Http.expectJson (\_ -> Elm.value "toMsg") (Elm.value "decoder")
@@ -27,6 +48,7 @@ generate request =
                                 (InterpolatedField.toElmExpression key)
                                 (InterpolatedField.toElmExpression value)
                         )
+                    |> List.append authHeaders
                     |> Elm.list
             , method = request.method |> Request.methodToString |> Elm.string
             , body = Elm.Gen.Http.emptyBody

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -118,7 +118,7 @@ update msg model =
                     model
                         |> updateCurrentRequest
                             (\req ->
-                                { req | url = s }
+                                { req | url = InterpolatedField.fromString s }
                             )
             , Cmd.none
             )

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -202,6 +202,15 @@ update msg model =
             , Cmd.none
             )
 
+        AuthChanged maybeAuth ->
+            ( model
+                |> updateCurrentRequest
+                    (\req ->
+                        { req | auth = maybeAuth }
+                    )
+            , Cmd.none
+            )
+
 
 updateFromBackend : ToFrontend -> Model -> ( Model, Cmd FrontendMsg )
 updateFromBackend msg model =

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -57,6 +57,7 @@ init url key =
       , currentRequest = Fusion.HTTP.emptyRequest
       , httpRequest = NotAsked
       , codeGenMode = ElmPages
+      , variables = Dict.empty
       }
     , Cmd.none
     )
@@ -159,7 +160,7 @@ update msg model =
             )
 
         RequestExecClicked ->
-            ( { model | rawString = "", httpRequest = Loading }, sendToBackend (RequestExecClicked_ model.currentRequest) )
+            ( { model | rawString = "", httpRequest = Loading }, sendToBackend (RequestExecClicked_ model.variables model.currentRequest) )
 
         ResetDecoder ->
             ( { model | fusionDecoder = EmptyDecoder }, Cmd.none )
@@ -190,6 +191,9 @@ update msg model =
 
         CodeGenModeChanged codeGenMode ->
             ( { model | codeGenMode = codeGenMode }, Cmd.none )
+
+        VariableUpdated variableUpdate ->
+            ( { model | variables = model.variables |> Dict.update variableUpdate.name (\_ -> Just variableUpdate.value) }, Cmd.none )
 
 
 updateFromBackend : ToFrontend -> Model -> ( Model, Cmd FrontendMsg )

--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -193,7 +193,14 @@ update msg model =
             ( { model | codeGenMode = codeGenMode }, Cmd.none )
 
         VariableUpdated variableUpdate ->
-            ( { model | variables = model.variables |> Dict.update variableUpdate.name (\_ -> Just variableUpdate.value) }, Cmd.none )
+            ( { model | variables = model.variables |> Dict.update variableUpdate.name (\_ -> Just variableUpdate.value) }
+            , Cmd.none
+            )
+
+        DeleteVariable variableName ->
+            ( { model | variables = model.variables |> Dict.remove variableName }
+            , Cmd.none
+            )
 
 
 updateFromBackend : ToFrontend -> Model -> ( Model, Cmd FrontendMsg )

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -14,6 +14,7 @@ import Fusion.Types exposing (FusionDecoder(..), HttpError, JsonValue(..), TType
 import Fusion.View
 import Helpers exposing (..)
 import Http exposing (..)
+import InterpolatedField
 import Json.Decode as D
 import List.Extra as List
 import RemoteData exposing (..)
@@ -35,7 +36,7 @@ emptyRequest : Request
 emptyRequest =
     { method = Request.GET
     , headers = []
-    , url = "https://jsonplaceholder.typicode.com/posts/1"
+    , url = "https://jsonplaceholder.typicode.com/posts/1" |> InterpolatedField.fromString
     , body = Request.StringBody "application/x-www-form-urlencoded" ""
     , timeout = Nothing
     }
@@ -175,7 +176,7 @@ view model =
             ]
         , Input.multiline [ padding 5 ]
             { onChange = RequestUrlChanged
-            , text = model.currentRequest.url
+            , text = model.currentRequest.url |> InterpolatedField.toString
             , placeholder =
                 Just (Input.placeholder [] <| text "the HTTP URL")
             , label = Input.labelHidden "request url input"

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -282,7 +282,7 @@ elmPagesCodeGen model =
                     Fusion.Json.decoderFromTType tType
     in
     """import DataSource.Http
-import Secrets
+import Pages.Secrets
 import OptimizedDecoder as D
 import OptimizedDecoder.Pipeline exposing (required)
 

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -316,7 +316,7 @@ import Json.Decode as D
 import Json.Decode.Pipeline exposing (required)
 
    
-   """
+"""
         ++ (model.currentRequest
                 |> ElmHttpGenerator.generate
                 |> Elm.declarationToString

--- a/src/InterpolatedField.elm
+++ b/src/InterpolatedField.elm
@@ -1,4 +1,4 @@
-module InterpolatedField exposing (Content(..), InterpolatedField(..), InterpolationField(..), Variable(..), fieldParser, fromString, interpolate, interpolationField, referencedVariables, statementsHelp, toElmExpression, toElmVar, toString, tokenParser, variableName)
+module InterpolatedField exposing (Content(..), InterpolatedField(..), InterpolationField(..), Variable(..), fieldParser, fromString, interpolate, interpolationField, rawVariableName, referencedVariables, statementsHelp, toElmExpression, toElmVar, toString, tokenParser)
 
 import Dict exposing (Dict)
 import Elm
@@ -12,8 +12,8 @@ type InterpolatedField
     = InterpolatedField String
 
 
-variableName : Variable -> String
-variableName (Variable name) =
+rawVariableName : Variable -> String
+rawVariableName (Variable name) =
     name
 
 

--- a/src/Request.elm
+++ b/src/Request.elm
@@ -1,6 +1,6 @@
 module Request exposing (Body(..), Method(..), Request, convert, methodToString, referencedVariables)
 
-import Dict
+import Dict exposing (Dict)
 import Fusion.Types
 import Http
 import InterpolatedField exposing (InterpolatedField)
@@ -34,18 +34,18 @@ type Body
     | StringBody String String
 
 
-convert : Request -> Fusion.Types.Request
-convert request =
+convert : Dict String String -> Request -> Fusion.Types.Request
+convert variables request =
     { headers =
         request.headers
             |> List.map
                 (\( key, value ) ->
                     Http.header
-                        (InterpolatedField.interpolate Dict.empty key)
-                        (InterpolatedField.interpolate Dict.empty value)
+                        (InterpolatedField.interpolate variables key)
+                        (InterpolatedField.interpolate variables value)
                 )
     , body = Fusion.Types.Empty
-    , url = request.url |> InterpolatedField.interpolate Dict.empty
+    , url = request.url |> InterpolatedField.interpolate variables
     , method =
         case request.method of
             GET ->

--- a/src/Request.elm
+++ b/src/Request.elm
@@ -9,7 +9,7 @@ import InterpolatedField exposing (InterpolatedField)
 type alias Request =
     { method : Method
     , headers : List ( InterpolatedField, InterpolatedField )
-    , url : String
+    , url : InterpolatedField
     , body : Body
     , timeout : Maybe Float
 
@@ -45,7 +45,7 @@ convert request =
                         (InterpolatedField.interpolate Dict.empty value)
                 )
     , body = Fusion.Types.Empty
-    , url = request.url
+    , url = request.url |> InterpolatedField.interpolate Dict.empty
     , method =
         case request.method of
             GET ->

--- a/src/Request.elm
+++ b/src/Request.elm
@@ -1,4 +1,4 @@
-module Request exposing (Body(..), Method(..), Request, convert, methodToString)
+module Request exposing (Body(..), Method(..), Request, convert, methodToString, referencedVariables)
 
 import Dict
 import Fusion.Types
@@ -65,3 +65,13 @@ methodToString method =
 
         POST ->
             "POST"
+
+
+referencedVariables : Request -> List InterpolatedField.Variable
+referencedVariables request =
+    request.headers
+        |> List.concatMap
+            (\( key, value ) ->
+                InterpolatedField.referencedVariables key ++ InterpolatedField.referencedVariables value
+            )
+        |> List.append (InterpolatedField.referencedVariables request.url)

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -34,7 +34,7 @@ type FrontendMsg
     | CodeGenModeChanged CodeGenMode
     | RequestUrlChanged String
     | VariableUpdated { name : String, value : String }
-      --| DeleteVariable String
+    | DeleteVariable String
     | RequestHeadersChanged String
     | RequestBodyChanged String
     | RequestExecClicked

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -37,6 +37,7 @@ type FrontendMsg
     | DeleteVariable String
     | RequestHeadersChanged String
     | RequestBodyChanged String
+    | AuthChanged (Maybe Request.Auth)
     | RequestExecClicked
     | ResetDecoder
     | JsonAddField (List String) String JsonValue

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -22,6 +22,7 @@ type alias FrontendModel =
     , currentRequest : Request.Request
     , httpRequest : RemoteData HttpError String
     , codeGenMode : CodeGenMode
+    , variables : Dict String String
     }
 
 
@@ -32,6 +33,8 @@ type FrontendMsg
     | RequestHttpMethodChanged Request.Method
     | CodeGenModeChanged CodeGenMode
     | RequestUrlChanged String
+    | VariableUpdated { name : String, value : String }
+      --| DeleteVariable String
     | RequestHeadersChanged String
     | RequestBodyChanged String
     | RequestExecClicked
@@ -48,7 +51,7 @@ type CodeGenMode
 
 
 type ToBackend
-    = RequestExecClicked_ Request.Request
+    = RequestExecClicked_ (Dict String String) Request.Request
     | NoOpToBackend
 
 

--- a/tests/ElmHttpGeneratorTest.elm
+++ b/tests/ElmHttpGeneratorTest.elm
@@ -53,6 +53,33 @@ suite =
         , timeout = Nothing
         , tracker = Nothing
         }"""
+        , test "GET with parameters" <|
+            \() ->
+                { url = "https://example.com"
+                , method = Request.GET
+                , body = Request.Empty
+                , headers =
+                    [ ( "accept-language", "${PREFERRED_LANGUAGE};q=0.9" )
+                    , ( "Referer", "http://www.wikipedia.org/" )
+                    ]
+                }
+                    |> toRequest
+                    |> ElmHttpGenerator.generate
+                    |> Elm.declarationToString
+                    |> Expect.equal
+                        """request toMsg preferredLanguage =
+    Http.request
+        { method = "GET"
+        , headers =
+            [ Http.header "accept-language" (preferredLanguage ++ ";q=0.9")
+            , Http.header "Referer" "http://www.wikipedia.org/"
+            ]
+        , url = "https://example.com"
+        , body = Http.emptyBody
+        , expect = Http.expectJson toMsg decoder
+        , timeout = Nothing
+        , tracker = Nothing
+        }"""
         ]
 
 

--- a/tests/ElmHttpGeneratorTest.elm
+++ b/tests/ElmHttpGeneratorTest.elm
@@ -16,8 +16,8 @@ suite =
                 { url = "https://example.com"
                 , method = Request.GET
                 , body = Request.Empty
-                , headers =
-                    []
+                , headers = []
+                , auth = Nothing
                 }
                     |> toRequest
                     |> ElmHttpGenerator.generate
@@ -35,6 +35,7 @@ suite =
                     [ ( "accept-language", "en-US,en;q=0.9" )
                     , ( "Referer", "http://www.wikipedia.org/" )
                     ]
+                , auth = Nothing
                 }
                     |> toRequest
                     |> ElmHttpGenerator.generate
@@ -62,6 +63,7 @@ suite =
                     [ ( "accept-language", "${PREFERRED_LANGUAGE};q=0.9" )
                     , ( "Referer", "http://www.wikipedia.org/" )
                     ]
+                , auth = Nothing
                 }
                     |> toRequest
                     |> ElmHttpGenerator.generate
@@ -80,6 +82,40 @@ suite =
         , timeout = Nothing
         , tracker = Nothing
         }"""
+        , test "with Basic Auth" <|
+            \() ->
+                { url = "https://api.mux.com/video/v1/assets/${ASSET_ID}"
+                , method = Request.GET
+                , body = Request.Empty
+                , headers =
+                    [ ( "Content-Type", "application/json" )
+                    ]
+                , auth =
+                    Request.BasicAuth
+                        { username = "${MUX_TOKEN_ID}" |> InterpolatedField.fromString
+                        , password = "${MUX_TOKEN_SECRET}" |> InterpolatedField.fromString
+                        }
+                        |> Just
+                }
+                    |> toRequest
+                    |> ElmHttpGenerator.generate
+                    |> Elm.declarationToString
+                    |> Expect.equal
+                        """request toMsg muxTokenId muxTokenSecret assetId =
+    Http.request
+        { method = "GET"
+        , headers =
+            [ Http.header
+                "Authorization"
+                (Base64.encode (muxTokenId ++ ":" ++ muxTokenSecret))
+            , Http.header "Content-Type" "application/json"
+            ]
+        , url = "https://api.mux.com/video/v1/assets/" ++ assetId
+        , body = Http.emptyBody
+        , expect = Http.expectJson toMsg decoder
+        , timeout = Nothing
+        , tracker = Nothing
+        }"""
         ]
 
 
@@ -88,10 +124,11 @@ toRequest :
     , method : Request.Method
     , body : Request.Body
     , headers : List ( String, String )
+    , auth : Maybe Request.Auth
     }
     -> Request
 toRequest request =
-    { url = request.url
+    { url = request.url |> InterpolatedField.fromString
     , method = request.method
     , body = request.body
     , headers =
@@ -103,4 +140,5 @@ toRequest request =
                     )
                 )
     , timeout = Nothing
+    , auth = request.auth
     }


### PR DESCRIPTION
I resolved some merge conflicts that were in #2, so I'll close that one and just include those fixes in here.

In addition to the fixes in #2, this PR includes:

- UI to input variable values (used to perform request)
- UI to select Basic auth or no auth
- Parses --user or -u curl option to use basic auth
- When basic auth is present, generated code uses Base64.encode to set Authorization header value appropriately (and of course uses interpolated variables as in other fields 😄 )
