### PR TITLE
Handle Content-type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "hasInstallScript": true,
       "devDependencies": {
-        "elm-tooling": "^1.6.0"
+        "elm-tooling": "1.7.0"
       }
     },
     "node_modules/elm-tooling": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.6.0.tgz",
-      "integrity": "sha512-quliLTmqEcqqFZEcJKnYcZ9BrL1K2sYvtryQl6BfaMD6HaI8oRaZYDPY/Ihdo7X7t7mY5TbSlrcxv6coJgWwtA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.7.0.tgz",
+      "integrity": "sha512-EHZ54voWrG3BhUONbH/wFw5U95H6N7R4QFgXHDrPIaDBDdeyNkpFu4QWArSWkhzxyCF7hqT8ya2yy7SferDsgg==",
       "dev": true,
       "bin": {
         "elm-tooling": "index.js"
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "elm-tooling": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.6.0.tgz",
-      "integrity": "sha512-quliLTmqEcqqFZEcJKnYcZ9BrL1K2sYvtryQl6BfaMD6HaI8oRaZYDPY/Ihdo7X7t7mY5TbSlrcxv6coJgWwtA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.7.0.tgz",
+      "integrity": "sha512-EHZ54voWrG3BhUONbH/wFw5U95H6N7R4QFgXHDrPIaDBDdeyNkpFu4QWArSWkhzxyCF7hqT8ya2yy7SferDsgg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "postinstall": "elm-tooling install"
   },
   "devDependencies": {
-    "elm-tooling": "^1.6.0"
+    "elm-tooling": "1.7.0"
   }
 }

--- a/src/CliArgsParser.elm
+++ b/src/CliArgsParser.elm
@@ -49,9 +49,9 @@ stringHelp revChunks =
         [ succeed (\chunk -> Loop (chunk :: revChunks))
             |. token "\\"
             |= oneOf
-                [ map (\_ -> "\n") (token "n")
-                , map (\_ -> "\t") (token "t")
-                , map (\_ -> "\u{000D}") (token "r")
+                [ map (\_ -> "\\n") (token "n")
+                , map (\_ -> "\\t") (token "t")
+                , map (\_ -> "\\r") (token "r")
                 ]
         , token "\""
             |> map (\_ -> Done (String.join "" (List.reverse revChunks)))
@@ -76,9 +76,9 @@ singleQuoteStringHelp revChunks =
         [ succeed (\chunk -> Loop (chunk :: revChunks))
             |. token "\\"
             |= oneOf
-                [ map (\_ -> "\n") (token "n")
-                , map (\_ -> "\t") (token "t")
-                , map (\_ -> "\u{000D}") (token "r")
+                [ map (\_ -> "\\n") (token "n")
+                , map (\_ -> "\\t") (token "t")
+                , map (\_ -> "\\r") (token "r")
                 ]
         , token "'"
             |> map (\_ -> Done (String.join "" (List.reverse revChunks)))

--- a/src/CurlGenerator.elm
+++ b/src/CurlGenerator.elm
@@ -1,5 +1,6 @@
 module CurlGenerator exposing (generate)
 
+import Fusion.Types
 import InterpolatedField
 import List.NonEmpty
 import Request exposing (Request)
@@ -33,15 +34,22 @@ generate request =
         Nothing ->
             []
     , case request.body of
-        Request.StringBody contentType body ->
+        Fusion.Types.StringBody contentType body ->
             [ "-H"
             , quoted ("Content-Type: " ++ contentType)
             , "-d"
             , quoted body
             ]
 
-        Request.Empty ->
+        Fusion.Types.Empty ->
             []
+
+        Fusion.Types.JsonBody jsonBody ->
+            [ "-H"
+            , quoted ("Content-Type: " ++ "application/json")
+            , "-d"
+            , quoted jsonBody
+            ]
     ]
         |> List.filterMap List.NonEmpty.fromList
         |> List.map List.NonEmpty.toList

--- a/src/DataSourceGenerator.elm
+++ b/src/DataSourceGenerator.elm
@@ -6,6 +6,7 @@ import Elm.Annotation
 import Elm.Gen.DataSource.Http
 import Elm.Gen.Pages.Secrets
 import Elm.Pattern
+import Fusion.Types
 import InterpolatedField
 import List.NonEmpty
 import Request exposing (Request)
@@ -137,11 +138,14 @@ generate variableDefinitions request =
 bodyGenerator : Request -> Elm.Expression
 bodyGenerator request =
     case request.body of
-        Request.Empty ->
+        Fusion.Types.Empty ->
             Elm.Gen.DataSource.Http.emptyBody
 
-        Request.StringBody contentType body ->
+        Fusion.Types.StringBody contentType body ->
             Elm.Gen.DataSource.Http.stringBody (Elm.string contentType) (Elm.string body)
+
+        Fusion.Types.JsonBody body ->
+            Elm.Gen.DataSource.Http.jsonBody (Elm.string body)
 
 
 indent : String -> String

--- a/src/Dict/CaseInsensitive.elm
+++ b/src/Dict/CaseInsensitive.elm
@@ -1,0 +1,71 @@
+module Dict.CaseInsensitive exposing
+    ( Dict(..)
+    , empty
+    , filter
+    , fromList
+    , get
+    , insert
+    , toDict
+    , toList
+    )
+
+import Dict
+
+
+type Dict a
+    = Dict (Dict.Dict String ( String, a ))
+
+
+insert : String -> value -> Dict value -> Dict value
+insert key value (Dict dict) =
+    dict
+        |> Dict.insert (String.toLower key) ( key, value )
+        |> Dict
+
+
+empty : Dict a
+empty =
+    Dict Dict.empty
+
+
+toDict : Dict value -> Dict.Dict String value
+toDict (Dict dict) =
+    dict
+        |> Dict.values
+        |> Dict.fromList
+
+
+toList : Dict value -> List ( String, value )
+toList (Dict dict) =
+    dict
+        |> Dict.values
+
+
+fromList : List ( String, value ) -> Dict value
+fromList list =
+    list
+        |> List.map
+            (\( key, value ) ->
+                ( String.toLower key
+                , ( key, value )
+                )
+            )
+        |> Dict.fromList
+        |> Dict
+
+
+get : String -> Dict value -> Maybe value
+get key (Dict dict) =
+    dict
+        |> Dict.get (String.toLower key)
+        |> Maybe.map Tuple.second
+
+
+filter : (String -> value -> Bool) -> Dict value -> Dict value
+filter filterFn (Dict dict) =
+    dict
+        |> Dict.filter
+            (\lowercaseKey ( _, value ) ->
+                filterFn lowercaseKey value
+            )
+        |> Dict

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -198,7 +198,7 @@ bodyView currentRequest =
                 StringBody _ _ ->
                     []
     in
-    column [ width fill ]
+    column [ width fill, spacing 10 ]
         [ row []
             [ buttonHilightOn (currentRequest.body == Empty) [] (RequestBodyChanged Empty) "Empty"
             , buttonHilightOn
@@ -212,39 +212,63 @@ bodyView currentRequest =
                 []
                 (RequestBodyChanged (JsonBody currentBodyString))
                 "JSON"
+            , buttonHilightOn
+                (case currentRequest.body of
+                    StringBody _ _ ->
+                        True
+
+                    _ ->
+                        False
+                )
+                []
+                (RequestBodyChanged (StringBody "application/plain" currentBodyString))
+                "Other"
             ]
         , if currentRequest.body == Empty then
             Element.none
 
           else
-            Input.multiline
-                ((if List.isEmpty validationErrors then
-                    []
+            Element.column [ width fill, spacing 10 ]
+                [ case currentRequest.body of
+                    StringBody contentType body ->
+                        Input.text [ padding 5 ]
+                            { onChange = \newContentType -> RequestBodyChanged (StringBody newContentType body)
+                            , text = contentType
+                            , placeholder = Just (Input.placeholder [] <| text "")
+                            , label = Input.labelLeft [ paddingEach { top = 0, bottom = 0, left = 0, right = 10 } ] (text "Content-Type")
+                            }
 
-                  else
-                    [ Element.Border.color (Element.rgb255 255 0 0) ]
-                 )
-                    ++ [ padding 5
-                       ]
-                )
-                { onChange =
-                    \newBody ->
-                        RequestBodyChanged
-                            (case currentRequest.body of
-                                Empty ->
-                                    StringBody "" newBody
+                    _ ->
+                        Element.none
+                , Input.multiline
+                    ((if List.isEmpty validationErrors then
+                        []
 
-                                JsonBody _ ->
-                                    JsonBody newBody
+                      else
+                        [ Element.Border.color (Element.rgb255 255 0 0) ]
+                     )
+                        ++ [ padding 5
+                           ]
+                    )
+                    { onChange =
+                        \newBody ->
+                            RequestBodyChanged
+                                (case currentRequest.body of
+                                    Empty ->
+                                        StringBody "" newBody
 
-                                StringBody mimeType _ ->
-                                    StringBody mimeType newBody
-                            )
-                , text = requestBodyString currentRequest
-                , placeholder = Just (Input.placeholder [] <| text "request body")
-                , label = Input.labelHidden "request body input"
-                , spellcheck = False
-                }
+                                    JsonBody _ ->
+                                        JsonBody newBody
+
+                                    StringBody mimeType _ ->
+                                        StringBody mimeType newBody
+                                )
+                    , text = requestBodyString currentRequest
+                    , placeholder = Just (Input.placeholder [] <| text "request body")
+                    , label = Input.labelHidden "request body input"
+                    , spellcheck = False
+                    }
+                ]
         , if List.isEmpty validationErrors then
             Element.none
 

--- a/src/Fusion/HTTP.elm
+++ b/src/Fusion/HTTP.elm
@@ -90,8 +90,8 @@ toHttpBody body =
         Fusion.Types.Empty ->
             Http.emptyBody
 
-        Fusion.Types.StringBody mime string ->
-            Http.stringBody "application/json" string
+        Fusion.Types.StringBody contentType string ->
+            Http.stringBody contentType string
 
         Fusion.Types.JsonBody json ->
             json

--- a/src/Fusion/Types.elm
+++ b/src/Fusion/Types.elm
@@ -95,10 +95,13 @@ type RequestMethod
 type RequestBody
     = Empty
     | StringBody String String
-    | Json
-    | File
-    | Bytes
-    | MultiPart (List RequestBodyPart)
+    | JsonBody String
+
+
+
+--| File
+--| Bytes
+--| MultiPart (List RequestBodyPart)
 
 
 type RequestBodyPart

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -42,7 +42,7 @@ type FrontendMsg
     | VariableUpdated { name : String, value : VariableDefinition }
     | DeleteVariable String
     | RequestHeadersChanged String
-    | RequestBodyChanged String
+    | RequestBodyChanged RequestBody
     | AuthChanged (Maybe Request.Auth)
     | MakeRequestClicked
     | ResetDecoder

--- a/tests/CaseInsensitiveDictTest.elm
+++ b/tests/CaseInsensitiveDictTest.elm
@@ -1,0 +1,34 @@
+module CaseInsensitiveDictTest exposing (..)
+
+import Dict exposing (Dict)
+import Dict.CaseInsensitive
+import Expect
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "CaseInsensitive.Dict"
+        [ test "empty" <|
+            \() ->
+                Dict.CaseInsensitive.empty
+                    |> Dict.CaseInsensitive.toDict
+                    |> Expect.equal Dict.empty
+        , test "insert key twice with different casing" <|
+            \() ->
+                Dict.CaseInsensitive.empty
+                    |> Dict.CaseInsensitive.insert "abc" 1
+                    |> Dict.CaseInsensitive.insert "ABC" 2
+                    |> Dict.CaseInsensitive.toDict
+                    |> Expect.equal
+                        (Dict.empty
+                            |> Dict.insert "ABC" 1
+                            |> Dict.insert "ABC" 2
+                        )
+        , test "get with different casing than insert" <|
+            \() ->
+                Dict.CaseInsensitive.empty
+                    |> Dict.CaseInsensitive.insert "ABC" 1
+                    |> Dict.CaseInsensitive.get "abc"
+                    |> Expect.equal (Just 1)
+        ]

--- a/tests/CurlGeneratorTest.elm
+++ b/tests/CurlGeneratorTest.elm
@@ -2,6 +2,7 @@ module CurlGeneratorTest exposing (..)
 
 import CurlGenerator
 import Expect
+import Fusion.Types
 import InterpolatedField
 import Request exposing (Request)
 import Test exposing (Test, describe, test)
@@ -14,7 +15,7 @@ suite =
             \() ->
                 { url = "http://en.wikipedia.org/"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "Accept-Language", "en-US,en;q=0.8" )
                     , ( "Referer", "http://www.wikipedia.org/" )
@@ -29,7 +30,7 @@ suite =
             \() ->
                 { url = "http://en.wikipedia.org/"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "Accept-Language", "en-US,en;q=0.8" )
                     , ( "Referer", "http://www.wikipedia.org/" )
@@ -50,7 +51,7 @@ suite =
             \() ->
                 { url = "https://reqbin.com/echo/post/json"
                 , method = Request.POST
-                , body = Request.StringBody "application/json" """{"login":"my_login","password":"my_password"}"""
+                , body = Fusion.Types.StringBody "application/json" """{"login":"my_login","password":"my_password"}"""
                 , headers = []
                 , auth = Nothing
                 }
@@ -64,7 +65,7 @@ suite =
 toRequest :
     { url : String
     , method : Request.Method
-    , body : Request.Body
+    , body : Fusion.Types.RequestBody
     , headers : List ( String, String )
     , auth : Maybe Request.Auth
     }

--- a/tests/CurlTest.elm
+++ b/tests/CurlTest.elm
@@ -4,6 +4,7 @@ import Cli.OptionsParser.MatchResult exposing (MatchResult(..))
 import Curl exposing (runCurl)
 import Dict
 import Expect exposing (Expectation)
+import Fusion.Types
 import InterpolatedField
 import Request exposing (Request)
 import Test exposing (..)
@@ -26,7 +27,7 @@ suite =
                             , ( "Referer", "http://www.wikipedia.org/" )
                             , ( "Connection", "keep-alive" )
                             ]
-                        , body = Request.Empty
+                        , body = Fusion.Types.Empty
                         , auth = Nothing
                         }
         , test "post" <|
@@ -41,13 +42,12 @@ suite =
                             , ( "Accept-Encoding", "gzip, deflate" )
                             , ( "Accept-Language", "en-US,en;q=0.8" )
                             , ( "User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36" )
-                            , ( "Content-Type", "application/x-www-form-urlencoded; charset=UTF-8" )
                             , ( "Accept", "*/*" )
                             , ( "Referer", "http://fiddle.jshell.net/_display/" )
                             , ( "X-Requested-With", "XMLHttpRequest" )
                             , ( "Connection", "keep-alive" )
                             ]
-                        , body = Request.StringBody "application/x-www-form-urlencoded; charset=UTF-8" "msg1=wow&msg2=such&msg3=data"
+                        , body = Fusion.Types.StringBody "application/x-www-form-urlencoded; charset=UTF-8" "msg1=wow&msg2=such&msg3=data"
                         , auth = Nothing
                         }
         , test "example from chrome dev tools copy" <|
@@ -82,36 +82,31 @@ suite =
                             , ( "sec-gpc", "1" )
                             , ( "user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36" )
                             ]
-                        , body = Request.Empty
+                        , body = Fusion.Types.Empty
                         , auth = Nothing
                         }
-        , test "JSON body" <|
+        , test "JSON body doesn't include duplicate content-type" <|
             \() ->
                 """'http://fiddle.jshell.net/echo/html/' -H 'Content-Type: application/json' --data '{"json": "data"}'"""
                     |> runCurl
                     |> expectRequest
                         { url = "http://fiddle.jshell.net/echo/html/"
                         , method = Request.POST
-                        , headers =
-                            [ ( "Content-Type", "application/json" )
-                            ]
-                        , body = Request.StringBody "application/json" """{"json": "data"}"""
+                        , headers = []
+                        , body = Fusion.Types.JsonBody """{"json": "data"}"""
                         , auth = Nothing
                         }
         , test "parses basic auth option from -u flag" <|
             \() ->
                 """https://api.mux.com/video/v1/assets/${ASSET_ID} \\
                      -X GET \\
-                     -H "Content-Type: application/json" \\
                      -u ${MUX_TOKEN_ID}:${MUX_TOKEN_SECRET}"""
                     |> runCurl
                     |> expectRequest
                         { url = "https://api.mux.com/video/v1/assets/${ASSET_ID}"
                         , method = Request.GET
-                        , headers =
-                            [ ( "Content-Type", "application/json" )
-                            ]
-                        , body = Request.Empty
+                        , headers = []
+                        , body = Fusion.Types.Empty
                         , auth =
                             Request.BasicAuth
                                 { username = "${MUX_TOKEN_ID}" |> InterpolatedField.fromString
@@ -126,7 +121,7 @@ expectRequest :
     { headers : List ( String, String )
     , method : Request.Method
     , url : String
-    , body : Request.Body
+    , body : Fusion.Types.RequestBody
     , auth : Maybe Request.Auth
     }
     -> MatchResult Request

--- a/tests/DataSourceGeneratorTest.elm
+++ b/tests/DataSourceGeneratorTest.elm
@@ -4,6 +4,7 @@ import DataSourceGenerator
 import Dict
 import Elm
 import Expect
+import Fusion.Types
 import InterpolatedField
 import Request exposing (Request)
 import Test exposing (Test, describe, test)
@@ -17,7 +18,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "accept-language", "en-US,en;q=0.9" )
                     , ( "Referer", "http://www.wikipedia.org/" )
@@ -45,7 +46,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.StringBody "application/json" """{"key":"value"}"""
+                , body = Fusion.Types.StringBody "application/json" """{"key":"value"}"""
                 , headers =
                     [ ( "accept-language", "en-US,en;q=0.9" )
                     , ( "Referer", "http://www.wikipedia.org/" )
@@ -76,7 +77,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "accept-language", "en-US,en;q=0.9" )
                     , ( "Authorization", "Basic ${AUTH_TOKEN}" )
@@ -107,7 +108,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "accept-language", "${PREFERRED_LANGUAGE};q=0.9" )
                     , ( "Authorization", "Basic ${AUTH_TOKEN}" )
@@ -139,7 +140,7 @@ suite =
             \() ->
                 { url = "https://api.mux.com/video/v1/assets/${ASSET_ID}"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "Content-Type", "application/json" )
                     ]
@@ -178,7 +179,7 @@ suite =
             \() ->
                 { url = "https://api.mux.com/video/v1/assets/${ASSET_ID}"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "Content-Type", "application/json" )
                     ]
@@ -222,7 +223,7 @@ suite =
 toRequest :
     { url : String
     , method : Request.Method
-    , body : Request.Body
+    , body : Fusion.Types.RequestBody
     , headers : List ( String, String )
     , auth : Maybe Request.Auth
     }

--- a/tests/ElmHttpGeneratorTest.elm
+++ b/tests/ElmHttpGeneratorTest.elm
@@ -3,6 +3,7 @@ module ElmHttpGeneratorTest exposing (suite)
 import Elm
 import ElmHttpGenerator
 import Expect
+import Fusion.Types
 import InterpolatedField
 import Request exposing (Request)
 import Test exposing (Test, describe, test)
@@ -15,7 +16,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers = []
                 , auth = Nothing
                 }
@@ -30,7 +31,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "accept-language", "en-US,en;q=0.9" )
                     , ( "Referer", "http://www.wikipedia.org/" )
@@ -58,7 +59,7 @@ suite =
             \() ->
                 { url = "https://example.com"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "accept-language", "${PREFERRED_LANGUAGE};q=0.9" )
                     , ( "Referer", "http://www.wikipedia.org/" )
@@ -86,7 +87,7 @@ suite =
             \() ->
                 { url = "https://api.mux.com/video/v1/assets/${ASSET_ID}"
                 , method = Request.GET
-                , body = Request.Empty
+                , body = Fusion.Types.Empty
                 , headers =
                     [ ( "Content-Type", "application/json" )
                     ]
@@ -122,7 +123,7 @@ suite =
 toRequest :
     { url : String
     , method : Request.Method
-    , body : Request.Body
+    , body : Fusion.Types.RequestBody
     , headers : List ( String, String )
     , auth : Maybe Request.Auth
     }


### PR DESCRIPTION
A few changes related to handling content-types:

- Began a UI for selecting HTTP body
- Parse `content-type` headers in the cURL parser into an HTTP Body data type
- Error messages for JSON HTTP body when it's invalid JSON
![Image 2021-12-06 at 3 31 06 PM](https://user-images.githubusercontent.com/1384166/144939263-2ff9d052-3caf-4761-bd0d-11c6190fbca3.jpg)

- Can set Empty HTTP Body through UI (so you could now distinguish between empty string body vs. no body to be precise)
- The CLI argument string parsing preserves `\n` within quoted strings - before this, it was causing invalid JSON because it turned it into literal newlines instead of `\n` characters